### PR TITLE
Enhancements to the media helm chart

### DIFF
--- a/helm-charts/media/templates/persistentvolume.yaml
+++ b/helm-charts/media/templates/persistentvolume.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: {{ include "media.fullname" . }}
+  name: media
   labels:
     {{- include "media.labels" . | nindent 4 }}
 spec:
@@ -12,5 +12,5 @@ spec:
   capacity:
     storage: 5Gi
   hostPath:
-    path: /opt/media
+    path: {{ .Values.mediaVolume.hostPath }}
     type: DirectoryOrCreate

--- a/helm-charts/media/templates/persistentvolumeclaim.yaml
+++ b/helm-charts/media/templates/persistentvolumeclaim.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "media.fullname" . }}
+  name: media
   labels:
     {{- include "media.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/media/values.yaml
+++ b/helm-charts/media/values.yaml
@@ -91,3 +91,7 @@ volumes:
 volumeMounts:
   - mountPath: /usr/share/nginx/html
     name: assets
+
+# media volume settings
+mediaVolume:
+  hostPath: /opt/media


### PR DESCRIPTION
Make the name of the persistentvolume a fixed value, independent of the release name used to install the chart; this allows the chart to be installed with arbitrary release names, though only allows one instance per namespace.

Also add 'mediaVolume' settings to values.yaml allowing the location of the media volume to be overridden.

Signed-off-by: Fergal Mc Carthy <fmccarthy@suse.com>