### PR TITLE
Initial metal3-deploy chart

### DIFF
--- a/helm-charts/metal3-deploy/.gitignore
+++ b/helm-charts/metal3-deploy/.gitignore
@@ -1,0 +1,5 @@
+# Ignore the Chart.lock
+/Chart.lock
+
+# Ignore charts/ subdirectory - dynamically created by helm dependency update
+/charts/

--- a/helm-charts/metal3-deploy/.helmignore
+++ b/helm-charts/metal3-deploy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/metal3-deploy/Chart.yaml
+++ b/helm-charts/metal3-deploy/Chart.yaml
@@ -1,0 +1,51 @@
+apiVersion: v2
+name: metal3-deploy
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+dependencies:
+  - name: media
+    version: 0.1.0
+    repository: "file://../media"
+    alias: metal3-media
+
+  - name: powerdns
+    version: 0.1.0
+    repository: "file://../powerdns"
+    alias: metal3-powerdns
+
+  # need to add the bitnami chart repo as well
+  - name: external-dns
+    version: 6.12.1
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: metal3-external-dns
+
+  - name: baremetal-operator
+    version: 0.1.1
+    repository: "file://../baremetal-operator"
+    alias: metal3-baremetal-operator
+
+  - name: ironic
+    version: 0.1.0
+    repository: "file://../ironic"
+    alias: metal3-ironic

--- a/helm-charts/metal3-deploy/README.md
+++ b/helm-charts/metal3-deploy/README.md
@@ -1,0 +1,13 @@
+# How to use this chart
+1. Run `helm dependency update .` in this chart to download/update the dependent charts.
+
+2. Identify the appropriate subchart values settings and create an appropriate override values YAML file.
+   * Ensure that the relevant ironic and baremetal-operator settings match.
+   * Ensure that the relevant powerdns and external-dns settings match.
+   * Ensure that the same DNS domain is configured for all relevant services.
+
+3. Install the chart using a command like the following:
+
+```console
+$ helm upgrade heavy-metal . --namespace metal-cubed --create-namespace --install --values ~/overrides.yaml
+```

--- a/helm-charts/metal3-deploy/templates/NOTES.txt
+++ b/helm-charts/metal3-deploy/templates/NOTES.txt
@@ -1,0 +1,3 @@
+TBD: Document the deployed application/service endpoints
+
+You should now be ready to install and configure ClusterAPI.

--- a/helm-charts/metal3-deploy/templates/_helpers.tpl
+++ b/helm-charts/metal3-deploy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metal3-deploy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metal3-deploy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metal3-deploy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metal3-deploy.labels" -}}
+helm.sh/chart: {{ include "metal3-deploy.chart" . }}
+{{ include "metal3-deploy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metal3-deploy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metal3-deploy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metal3-deploy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metal3-deploy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -1,0 +1,182 @@
+# The metal3-deploy chart is a parent chart that installs
+# all of the other charts that a metal3 deployment needs,
+# but doesn't actually deploy any services itself.
+
+# The reference examples below are for a single node management cluster,
+# connected to the to network where the baremental nodes (that it will
+# be managing are located) via with it's 'ens4' network interface, with
+# associated IP 192.168.20.5. The metal3 services will be automatically
+# registered as members of the 'suse.baremetal' DNS domain.
+
+# Define a global default for other charts to leverage.
+global:
+
+  # DNS domain that all services will either be members of, or, in the
+  # case of external-dns and pdns, manage.
+  dnsDomain: suse.baremetal
+
+  # specify comma serparate beginning and end of the range of IP
+  # addresses the DHCP server will manage.
+  dhcpRange: 192.168.20.20,192.168.20.80
+
+  # Network interface on which provisioning network can be accessed
+  provisioningInterface: ens4
+
+  # IP Address assigned to network interface on provisioning network
+  provisioningIP: 192.168.20.5
+
+
+#
+# media service
+#
+
+# Override any settings for the metal3 media service here
+metal3-media:
+  ingress:
+    annotations:
+      # The IP to register with external-dns for this service
+      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  # location where media files should be placed so that they are
+  # available to the Ironic deployment services.
+  mediaVolume:
+    hostPath: /opt/media
+
+
+#
+# powerdns service
+#
+
+# Override any settings for the metal3 powerdns service here
+metal3-powerdns:
+
+  ingress:
+    annotations:
+      # The IP to register with external-dns for this service
+      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  powerdns:
+
+    api:
+      # key used to authenticate PowerDNS API requests
+      key: "654321fedcba"
+
+    webserver:
+      # port that PowerDNS webserver listens for API requests on
+      port: 8081
+
+  service:
+
+    # cluster IP that powerDNS service will be accessible at
+    ip: "10.43.255.251"
+
+  zone:
+
+    # DNS domain that PowerDNS will manage
+    # *Must match the global.dnsDomain setting specified above*
+    name: suse.baremetal
+
+
+#
+# external-dns service
+#
+
+# Override any settings for the metal3 external-dns service here
+metal3-external-dns:
+
+  # external-dns will monitor these sources of IP address to name
+  # mappings and automatically add/remove DNS entries as needed.
+  sources:
+    - service
+    - ingress
+
+  # DNS domain(s) that external DNS will manage entries for
+  domainFilters:
+    # *Must match global.dnsDomain setting specified*
+    - suse.baremetal
+
+  # which DNS provider backend to use
+  provider: pdns
+
+  # PowerDNS backend specific config settings
+  pdns:
+
+    # PowerDNS API request URL
+    # *Must match metal3-powerdns.service.ip*
+    apiUrl: "http://10.43.255.251"
+
+    # PowerDNS API request port
+    # *Must match metal3-powerdns.powerdns.webserver.port*
+    apiPort: "8081"
+
+    # PowerDNS API request authentication key
+    # *Must match metal3-powerdns.powerdns.webserver.port*
+    apiKey: "654321fedcba"
+
+
+  # 'sync' allows external-dns to add/remove entries; the default
+  # 'upsert-only' only allows entries to be added with PowerDNS
+  # backend.
+  policy: sync
+
+
+#
+# baremetal-operator service
+#
+
+# Override any settings for the metal3 baremetal-operator service here
+metal3-baremetal-operator:
+
+  ingress:
+    annotations:
+      # The IP to register with external-dns for this service
+      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  baremetaloperator:
+
+    # Specify comma serparate beginning and end of the range of IP
+    # addresses the DHCP server will manage.
+    # *Must match value specified for global.dhcpRange above*
+    dhcpRange: 192.168.20.20,192.168.20.80
+
+    # Network interface on which provisioning network can be accessed
+    # *Must match value specified for global.provisioningInterface above*
+    provisioningInterface: ens4
+
+    # IP Address assigned to network interface on provisioning network
+    # *Must match value specified for global.provisioningIp above*
+    provisioningIp:  192.168.20.5
+
+
+#
+# ironic service
+#
+
+# Override any settings for the metal3 ironic service here
+metal3-ironic:
+  ingress:
+    annotations:
+      # The IP to register with external-dns for this service
+      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  baremetaloperator:
+
+    # IP address of the router associated with the specified DHCP
+    # address range 
+    dnsmasqDefaultRouter: 192.168.21.254
+
+    # IP address of the DNS server that dnsmasq should use
+    dnsmasqDnsServerAddress: 192.168.20.5
+
+    # specify comma serparate beginning and end of the range of IP
+    # addresses the DHCP server will manage.
+    # *Must match value specified for global.dhcpRange above*
+    dhcpRange: 192.168.20.20,192.168.20.80
+
+    # Network interface on which provisioning network can be accessed
+    # *Must match value specified for global.provisioningInterface above*
+    provisioningInterface: ens4
+
+    # IP Address assigned to network interface on provisioning network
+    # *Must match value specified for global.provisioningIp above*
+    provisioningIp: 192.168.20.5


### PR DESCRIPTION
Pulls in dependent charts, and sets up consistent overrides for their relevant settings.

Currently the templates/NOTES.txt contains static content; this should be expanded to report the deployed application/service endpoints as well as identify next steps for the user to perform.

Add git ignorance for the Chart.lock file and charts/ subdirectory that is dynamically created by the 'helm dependency update' command.

NOTE:
To test this chart run `helm dependency update` in the metal3-deploy chart directory, and then install it as normal.

Signed-off-by: Fergal Mc Carthy <fmccarthy@suse.com>