### PR TITLE
add support to disable DHCP requests

### DIFF
--- a/helm-charts/ironic/Chart.yaml
+++ b/helm-charts/ironic/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/ironic/ironic-config/dnsmasq.conf.j2
+++ b/helm-charts/ironic/ironic-config/dnsmasq.conf.j2
@@ -31,6 +31,15 @@ dhcp-boot=tag:efi,tag:!ipxe,snponly.efi
 dhcp-boot=/undionly.kpxe,{{ env.IRONIC_IP }}
 {% endif %}
 
+{%- if env.DHCP_HOSTS | length %}
+{% for mac in (env.DHCP_HOSTS | replace('-', ':') | replace('\\,', ',')).split(',') -%}
+{%- if mac | length %}
+dhcp-host={{ mac }}
+{% endif %}
+{% endfor %}
+dhcp-ignore=tag:!known
+{% endif %}
+
 {% if env.IPV == "6" %}
 # IPv6 Configuration:
 enable-ra

--- a/helm-charts/ironic/templates/configmap.yaml
+++ b/helm-charts/ironic/templates/configmap.yaml
@@ -10,6 +10,9 @@ data:
   DEPLOY_KERNEL_URL: {{ tpl .deployKernelUrl $ }}
   DEPLOY_RAMDISK_URL: {{ tpl .deployRamdiskUrl $ }}
   DHCP_RANGE: {{ .dhcpRange }}
+  {{ if  .dhcpHosts }}
+  DHCP_HOSTS: {{ .dhcpHosts }}
+  {{ end }}
   DNSMASQ_BOOT_SERVER_ADDRESS: {{ tpl .bootServerAddress $ }}
   DNSMASQ_DEFAULT_ROUTER: {{ .dnsmasqDefaultRouter }}
   DNSMASQ_DNS_SERVER_ADDRESS: {{ .dnsmasqDnsServerAddress }}

--- a/helm-charts/ironic/values.yaml
+++ b/helm-charts/ironic/values.yaml
@@ -212,6 +212,9 @@ baremetaloperator:
   deployKernelUrl: "http://boot.ironic.{{ .Values.dnsDomain }}/images/ironic-python-agent.kernel"
   deployRamdiskUrl: "http://boot.ironic.{{ .Values.dnsDomain }}/images/ironic-python-agent.initramfs"
   dhcpRange: "192.168.20.20,192.168.20.80"
+  # If no dhpHosts set, all mac addresses acknowledged
+  dhcpHosts: ""
+
 
   bootServerAddress: "boot.ironic.{{ .Values.dnsDomain }}"
   dnsmasqDefaultRouter: "192.168.21.254"

--- a/helm-charts/metal3-deploy/Chart.yaml
+++ b/helm-charts/metal3-deploy/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     alias: metal3-baremetal-operator
 
   - name: ironic
-    version: 0.1.0
+    version: 0.1.1
     repository: "file://../ironic"
     alias: metal3-ironic

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -172,6 +172,8 @@ metal3-ironic:
     # addresses the DHCP server will manage.
     # *Must match value specified for global.dhcpRange above*
     dhcpRange: 192.168.20.20,192.168.20.80
+    # If no dhpHosts set, all mac addresses will be acknowledged
+    dhcpHosts: ""
 
     # Network interface on which provisioning network can be accessed
     # *Must match value specified for global.provisioningInterface above*


### PR DESCRIPTION
To support multiple DHPC servers in the same network requires limitting responses to know MAC addresses. The support will be done in phases. The first phase to to disable responses for any unknown MAC address

This is done by setting:
dhcp-ignore=tag:!known in the dns config file.

This can be done through ironic/values.yaml

Or via overrides.