### PR TITLE
Cleanup and consolidate the chart configurations

### DIFF
--- a/helm-charts/baremetal-operator/templates/configmap-ironic.yaml
+++ b/helm-charts/baremetal-operator/templates/configmap-ironic.yaml
@@ -4,13 +4,13 @@ data:
   CACHEURL: {{ .cacheUrl }}
   DEPLOY_KERNEL_URL: {{ .deployKernelUrl }}
   DEPLOY_RAMDISK_URL: {{ .deployRamdiskUrl }}
-  DHCP_RANGE: {{ .dhcpRange }}
   HTTP_PORT: {{ .httpPort | quote }}
   IRONIC_ENDPOINT: {{ .ironicEndpoint }}
   IRONIC_INSPECTOR_ENDPOINT: {{ .ironicInspectorEndpoint }}
-  PROVISIONING_INTERFACE: {{ .provisioningInterface }}
-  PROVISIONING_IP: {{ .provisioningIp }}
 {{- end }}
+  DHCP_RANGE: {{ .Values.global.dhcpRange }}
+  PROVISIONING_INTERFACE: {{ .Values.global.provisioningInterface }}
+  PROVISIONING_IP: {{ .Values.global.provisioningIP }}
   IRONIC_FAST_TRACK: "true"
   RESTART_CONTAINER_CERTIFICATE_UPDATED: "false"
 kind: ConfigMap

--- a/helm-charts/baremetal-operator/values.yaml
+++ b/helm-charts/baremetal-operator/values.yaml
@@ -2,6 +2,18 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+
+  # specify comma serparate beginning and end of the range of IP
+  # addresses the DHCP server will manage.
+  dhcpRange: 192.168.20.20,192.168.20.80
+
+  # Network interface on which provisioning network can be accessed
+  provisioningInterface: ens4
+
+  # IP Address assigned to network interface on provisioning network
+  provisioningIP: 192.168.20.5
+
 replicaCount: 1
 
 image:
@@ -85,10 +97,7 @@ baremetaloperator:
   cacheUrl: "http://cache.ironic.suse.baremetal/images"
   deployKernelUrl: "http://boot.ironic.suse.baremetal/images/ironic-python-agent.kernel"
   deployRamdiskUrl: "http://boot.ironic.suse.baremetal/images/ironic-python-agent.initramfs"
-  dhcpRange: "192.168.20.20,192.168.20.80"
   httpPort: "6180"
 
   ironicEndpoint: "http://api.ironic.suse.baremetal/v1/"
   ironicInspectorEndpoint: "http://inspector.ironic.suse.baremetal/v1/"
-  provisioningInterface: "ens4"
-  provisioningIp: "192.168.20.5"

--- a/helm-charts/ironic/templates/certificate-self-signed.yaml
+++ b/helm-charts/ironic/templates/certificate-self-signed.yaml
@@ -11,6 +11,6 @@ spec:
     name: ironic 
   secretName: ironic-cacert 
   ipAddresses:  
-    - {{ .Values.baremetaloperator.provisioningIp }} 
+    - {{ .Values.global.provisioningIP }} 
   {{- end -}}
 {{- end -}}  

--- a/helm-charts/ironic/templates/configmap.yaml
+++ b/helm-charts/ironic/templates/configmap.yaml
@@ -9,13 +9,11 @@ data:
   CACHEURL: {{ tpl .cacheUrl $ }}
   DEPLOY_KERNEL_URL: {{ tpl .deployKernelUrl $ }}
   DEPLOY_RAMDISK_URL: {{ tpl .deployRamdiskUrl $ }}
-  DHCP_RANGE: {{ .dhcpRange }}
   {{ if  .dhcpHosts }}
   DHCP_HOSTS: {{ .dhcpHosts }}
   {{ end }}
   DNSMASQ_BOOT_SERVER_ADDRESS: {{ tpl .bootServerAddress $ }}
-  DNSMASQ_DEFAULT_ROUTER: {{ .dnsmasqDefaultRouter }}
-  DNSMASQ_DNS_SERVER_ADDRESS: {{ .dnsmasqDnsServerAddress }}
+  DNSMASQ_DNS_SERVER_ADDRESS: {{ tpl .dnsmasqDnsServerAddress $ }}
   HTTP_PORT: {{ .httpPort | quote }}
   IPA_BASEURI: {{ .ipaBaseUri }}
   IRONIC_API_BASE_URL: {{ tpl .ironicApiUrl $ }}
@@ -29,9 +27,11 @@ data:
   IRONIC_INSPECTOR_HTTPD_SERVER_NAME: {{ tpl .ironicInspectorHost $ }}
   IRONIC_RAMDISK_SSH_KEY: {{ .ironicRamdiskSshKey }}
   IRONIC_VMEDIA_HTTPD_SERVER_NAME: {{ tpl .bootServerAddress $ }} 
-  PROVISIONING_INTERFACE: {{ .provisioningInterface }} 
-  PROVISIONING_IP: {{ .provisioningIp }}
   {{- end }}
+  DHCP_RANGE: {{ .Values.global.dhcpRange }}
+  DNSMASQ_DEFAULT_ROUTER: {{ .Values.global.dnsmasqDefaultRouter }}
+  PROVISIONING_INTERFACE: {{ .Values.global.provisioningInterface }}
+  PROVISIONING_IP: {{ .Values.global.provisioningIP }}
   IRONIC_INSPECTOR_VLAN_INTERFACES: all
   IRONIC_ILO_USE_SWIFT: "false"
   IRONIC_ILO_USE_WEB_SERVER_FOR_IMAGES: "true"

--- a/helm-charts/ironic/templates/ingress.yaml
+++ b/helm-charts/ironic/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "ironic.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with $_ := merge .Values.ingress.annotations $.Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}      
   {{- end }}

--- a/helm-charts/ironic/values.yaml
+++ b/helm-charts/ironic/values.yaml
@@ -2,6 +2,33 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+
+  # DNS domain that all services will either be members of, or, in the
+  # case of external-dns and pdns, manage.
+  dnsDomain: suse.baremetal
+
+  # IP address of the router associated with the specified DHCP
+  # address range
+  dnsmasqDefaultRouter: 192.168.21.254
+
+  # specify comma serparate beginning and end of the range of IP
+  # addresses the DHCP server will manage.
+  dhcpRange: 192.168.20.20,192.168.20.80
+
+  # Network interface on which provisioning network can be accessed
+  provisioningInterface: ens4
+
+  # IP Address assigned to network interface on provisioning network
+  provisioningIP: 192.168.20.5
+
+  # Global ingress annotations that is shared by all the ingress services.
+  # For example, use it to override extern-dns records.
+  ingress:
+    annotations: {}
+      # The IP to register with external-dns for this service
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
 replicaCount: 1
 
 image:
@@ -35,31 +62,29 @@ service:
     port: 5050  
   - type: NodePort 
 
-dnsDomain: suse.baremetal
-
 ingress:
   enabled: true 
   className: ""
-  annotations: {} 
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: "api.ironic.{{ .Values.dnsDomain }}"
+    - host: "api.ironic.{{ .Values.global.dnsDomain }}"
       paths:
         - path: /
           pathType: Prefix 
           portname: api
-    - host: "inspector.ironic.{{ .Values.dnsDomain }}"
+    - host: "inspector.ironic.{{ .Values.global.dnsDomain }}"
       paths:
         - path: /
           pathType: Prefix
           portname: inspector
-    - host: "boot.ironic.{{ .Values.dnsDomain }}"
+    - host: "boot.ironic.{{ .Values.global.dnsDomain }}"
       paths:
         - path: /
           pathType: Prefix
           portname: httpd
-    - host: "cache.ironic.{{ .Values.dnsDomain }}"
+    - host: "cache.ironic.{{ .Values.global.dnsDomain }}"
       paths:
         - path: /
           pathType: Prefix
@@ -208,31 +233,25 @@ volumes:
     configMapName: ironic-ipa-downloader
 
 baremetaloperator:
-  cacheUrl: "http://cache.ironic.{{ .Values.dnsDomain }}/images"      
-  deployKernelUrl: "http://boot.ironic.{{ .Values.dnsDomain }}/images/ironic-python-agent.kernel"
-  deployRamdiskUrl: "http://boot.ironic.{{ .Values.dnsDomain }}/images/ironic-python-agent.initramfs"
-  dhcpRange: "192.168.20.20,192.168.20.80"
+  cacheUrl: "http://cache.ironic.{{ .Values.global.dnsDomain }}/images"
+  deployKernelUrl: "http://boot.ironic.{{ .Values.global.dnsDomain }}/images/ironic-python-agent.kernel"
+  deployRamdiskUrl: "http://boot.ironic.{{ .Values.global.dnsDomain }}/images/ironic-python-agent.initramfs"
   # If no dhpHosts set, all mac addresses acknowledged
   dhcpHosts: ""
 
-
-  bootServerAddress: "boot.ironic.{{ .Values.dnsDomain }}"
-  dnsmasqDefaultRouter: "192.168.21.254"
-  dnsmasqDnsServerAddress: "192.168.20.5"
+  bootServerAddress: "boot.ironic.{{ .Values.global.dnsDomain }}"
+  dnsmasqDnsServerAddress: "{{ .Values.global.provisioningIP }}"
   httpPort: "6180"
 
   ipaBaseUri: "http://10.84.144.252/metal3"
-  ironicApiUrl: "http://api.ironic.{{ .Values.dnsDomain }}"
-  ironicApiHost: "api.ironic.{{ .Values.dnsDomain }}"
-  ironicBootBaseUrl: "http://boot.ironic.{{ .Values.dnsDomain }}"
-  ironicEndpoint: "http://api.ironic.{{ .Values.dnsDomain }}/v1/"
-  ironicInspectorUrl: "http://inspector.ironic.{{ .Values.dnsDomain }}" 
-  ironicInspectorEndpoint: "http://inspector.ironic.{{ .Values.dnsDomain }}/v1/"
-  ironicInspectorHost: "inspector.ironic.{{ .Values.dnsDomain }}" 
+  ironicApiUrl: "http://api.ironic.{{ .Values.global.dnsDomain }}"
+  ironicApiHost: "api.ironic.{{ .Values.global.dnsDomain }}"
+  ironicBootBaseUrl: "http://boot.ironic.{{ .Values.global.dnsDomain }}"
+  ironicEndpoint: "http://api.ironic.{{ .Values.global.dnsDomain }}/v1/"
+  ironicInspectorUrl: "http://inspector.ironic.{{ .Values.global.dnsDomain }}"
+  ironicInspectorEndpoint: "http://inspector.ironic.{{ .Values.global.dnsDomain }}/v1/"
+  ironicInspectorHost: "inspector.ironic.{{ .Values.global.dnsDomain }}"
   ironicRamdiskSshKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHGYaMrmsmLbv3O6Fj+0kg/U8iY7pcbO9HkbN88OAD+5 colstrom@headnode"
-
-  provisioningInterface: "ens4"
-  provisioningIp: "192.168.20.5"
   mariadbPassword: "changeme"   
   cloudflareApiToken: "foo"
   ironichostNetwork: true

--- a/helm-charts/media/templates/ingress.yaml
+++ b/helm-charts/media/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "media.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with $_ := merge .Values.ingress.annotations $.Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-charts/media/values.yaml
+++ b/helm-charts/media/values.yaml
@@ -2,6 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Global ingress annotations that is shared by all the ingress services.
+  # For example, use it to override extern-dns records.
+  ingress:
+    annotations: {}
+      # The IP to register with external-dns for this service
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
 replicaCount: 1
 
 image:

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -15,6 +15,10 @@ global:
   # case of external-dns and pdns, manage.
   dnsDomain: suse.baremetal
 
+  # IP address of the router associated with the specified DHCP
+  # address range
+  dnsmasqDefaultRouter: 192.168.21.254
+
   # specify comma serparate beginning and end of the range of IP
   # addresses the DHCP server will manage.
   dhcpRange: 192.168.20.20,192.168.20.80
@@ -25,6 +29,13 @@ global:
   # IP Address assigned to network interface on provisioning network
   provisioningIP: 192.168.20.5
 
+  # Global ingress annotations that is shared by all the ingress services.
+  # For example, use it to override extern-dns records.
+  ingress:
+    annotations: {}
+      # The IP to register with external-dns for this service
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
 
 #
 # media service
@@ -33,9 +44,9 @@ global:
 # Override any settings for the metal3 media service here
 metal3-media:
   ingress:
-    annotations:
+    annotations: {}
       # The IP to register with external-dns for this service
-      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
 
   # location where media files should be placed so that they are
   # available to the Ironic deployment services.
@@ -51,9 +62,9 @@ metal3-media:
 metal3-powerdns:
 
   ingress:
-    annotations:
+    annotations: {}
       # The IP to register with external-dns for this service
-      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
 
   powerdns:
 
@@ -132,22 +143,6 @@ metal3-baremetal-operator:
       # The IP to register with external-dns for this service
       external-dns.alpha.kubernetes.io/target: 192.168.20.5
 
-  baremetaloperator:
-
-    # Specify comma serparate beginning and end of the range of IP
-    # addresses the DHCP server will manage.
-    # *Must match value specified for global.dhcpRange above*
-    dhcpRange: 192.168.20.20,192.168.20.80
-
-    # Network interface on which provisioning network can be accessed
-    # *Must match value specified for global.provisioningInterface above*
-    provisioningInterface: ens4
-
-    # IP Address assigned to network interface on provisioning network
-    # *Must match value specified for global.provisioningIp above*
-    provisioningIp:  192.168.20.5
-
-
 #
 # ironic service
 #
@@ -155,30 +150,11 @@ metal3-baremetal-operator:
 # Override any settings for the metal3 ironic service here
 metal3-ironic:
   ingress:
-    annotations:
+    annotations: {}
       # The IP to register with external-dns for this service
-      external-dns.alpha.kubernetes.io/target: 192.168.20.5
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
 
   baremetaloperator:
 
-    # IP address of the router associated with the specified DHCP
-    # address range 
-    dnsmasqDefaultRouter: 192.168.21.254
-
-    # IP address of the DNS server that dnsmasq should use
-    dnsmasqDnsServerAddress: 192.168.20.5
-
-    # specify comma serparate beginning and end of the range of IP
-    # addresses the DHCP server will manage.
-    # *Must match value specified for global.dhcpRange above*
-    dhcpRange: 192.168.20.20,192.168.20.80
     # If no dhpHosts set, all mac addresses will be acknowledged
     dhcpHosts: ""
-
-    # Network interface on which provisioning network can be accessed
-    # *Must match value specified for global.provisioningInterface above*
-    provisioningInterface: ens4
-
-    # IP Address assigned to network interface on provisioning network
-    # *Must match value specified for global.provisioningIp above*
-    provisioningIp: 192.168.20.5

--- a/helm-charts/powerdns/templates/ingress.yaml
+++ b/helm-charts/powerdns/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "powerdns.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with $_ := merge .Values.ingress.annotations $.Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -2,6 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Global ingress annotations that is shared by all the ingress services.
+  # For example, use it to override extern-dns records.
+  ingress:
+    annotations: {}
+      # The IP to register with external-dns for this service
+      #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
 image:
   repository: registry.opensuse.org/home/kberger65/bci/containerfile/suse/pdns
   pullPolicy: Always


### PR DESCRIPTION
Move the shared configurations to global so that we don't have to repeat them in every chart. Also, use reference whenever possible.

Signed-off-by: guangyee <gyee@suse.com>