### PR TITLE
Ensure proper DNS is used and fix a few inconsistencies

### DIFF
--- a/helm-charts/baremetal-operator/templates/deployment.yaml
+++ b/helm-charts/baremetal-operator/templates/deployment.yaml
@@ -86,3 +86,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: bmo-webhook-server-cert
+      {{- with .Values.global.dnsPolicy }}
+      dnsPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/helm-charts/ironic/templates/deployment.yaml
+++ b/helm-charts/ironic/templates/deployment.yaml
@@ -157,3 +157,11 @@ spec:
           defaultMode: 493
           name: ironic-certs       
       {{- end }}
+      {{- with .Values.global.dnsPolicy }}
+      dnsPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/media/templates/deployment.yaml
+++ b/helm-charts/media/templates/deployment.yaml
@@ -60,7 +60,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.dnsConfig }}
+      {{- with .Values.global.dnsPolicy }}
+      dnsPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -15,6 +15,14 @@ global:
   # case of external-dns and pdns, manage.
   dnsDomain: suse.baremetal
 
+  dnsPolicy: "None"
+
+  dnsConfig:
+    nameservers:
+    - 10.43.255.254
+    searches:
+    - suse.baremetal
+
   # IP address of the router associated with the specified DHCP
   # address range
   dnsmasqDefaultRouter: 192.168.21.254
@@ -79,7 +87,7 @@ metal3-powerdns:
   service:
 
     # cluster IP that powerDNS service will be accessible at
-    ip: "10.43.255.251"
+    ip: "10.43.255.254"
 
   zone:
 
@@ -114,7 +122,7 @@ metal3-external-dns:
 
     # PowerDNS API request URL
     # *Must match metal3-powerdns.service.ip*
-    apiUrl: "http://10.43.255.251"
+    apiUrl: "http://10.43.255.254"
 
     # PowerDNS API request port
     # *Must match metal3-powerdns.powerdns.webserver.port*


### PR DESCRIPTION
This PR makes the following changes:

1) The "deploy" template file for baremetal was named `deploy.yaml` . All other "deploy" templates are called deployment.yaml and this adheres to common practice. The deploy.yaml was renamed to deployment.yaml
2) The IP address for the PDNS server was listed in a few places as 10.43.255.251 and others as  10.43.255.254. These are all now 10.43.255.254
3) The baremetal and ironic containers were not using the pdns dns server but the native coredns that is part of rke2/k3s.  Variables have been added to ensure this is set correctly. Without this change, a "cannot lookup boot.ironic.suse.baremetal " error was seen in the ironic and baremetal container logs.


Signed-off-by: Keith Berger <kberger@suse.com>