### PR TITLE
Allow pdns to listen on host address

### DIFF
--- a/helm-charts/powerdns/templates/configmap.yaml
+++ b/helm-charts/powerdns/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
     {{ end }}
     default-soa-content={{ tpl .Values.zone.default_soa_content . }}
 
+
 {{ if (.Values.powerdns.api.key) }}
   01-api.conf: |
     api=yes
@@ -46,6 +47,7 @@ data:
     {{ $key }}={{ $value }}
     {{ end }}
     forward-zones={{ tpl .Values.powerdns.recursor.forward_zones .}}
+    local-address={{ .Values.global.pdnsIP | default "0.0.0.0"}}:53
 
 ---
 apiVersion: v1

--- a/helm-charts/powerdns/templates/deployment.yaml
+++ b/helm-charts/powerdns/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
               subPath: init-db.sh
             - name: pdns-persistent-storage
               mountPath: /var/lib/pdns
+      {{- with .Values.global.pdnsIP}}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -9,6 +9,10 @@ global:
     annotations: {}
       # The IP to register with external-dns for this service
       #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+  #pdnsIP: 192.168.20.5
+   # set pdnsIP to enable hostNetwork in the pdns container
+   # and bind pdns to port 53 using the pdsnIP address
+
 
 image:
   repository: registry.opensuse.org/home/kberger65/bci/containerfile/suse/pdns
@@ -154,7 +158,6 @@ powerdns:
     port: 53
     #For more details for the configuration entries for recursor, please check https://docs.powerdns.com/recursor/settings.html
     config: {
-              local-address: 0.0.0.0:53,
               dnssec: process-no-validate,
               allow-from: "0.0.0.0/0,::/0",
               max-cache-ttl: 600,


### PR DESCRIPTION
This PR adds an optional variable, pdnsIP in the values.yaml  which switches the pdns container to use a hostNetwork to allow for both internal and external cluster access to pdns.