### PR TITLE
Update pdnsIP info in powerdns and metal3-deploy helm charts

### DIFF
--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -37,6 +37,11 @@ global:
   # IP Address assigned to network interface on provisioning network
   provisioningIP: 192.168.20.5
 
+  # set pdnsIP to enable hostNetwork in the pdns-recursor container
+  # and bind pdns-recursor to port 53 using the pdnsIP address
+
+  #pdnsIP: 192.168.20.5
+
   # Global ingress annotations that is shared by all the ingress services.
   # For example, use it to override extern-dns records.
   ingress:

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -9,10 +9,11 @@ global:
     annotations: {}
       # The IP to register with external-dns for this service
       #external-dns.alpha.kubernetes.io/target: 192.168.20.5
-  #pdnsIP: 192.168.20.5
-   # set pdnsIP to enable hostNetwork in the pdns container
-   # and bind pdns to port 53 using the pdsnIP address
 
+  # set pdnsIP to enable hostNetwork in the pdns-recursor container
+  # and bind pdns-recursor to port 53 using the pdnsIP address
+
+  #pdnsIP: 192.168.20.5
 
 image:
   repository: registry.opensuse.org/isv/metal3/bci/containerfile/suse/pdns


### PR DESCRIPTION
This PR updates the entry for pdnsIP in both the powerdns and metal3-deploy values.yaml files. A typo was fixed and the text was adjusted for reflect the pdns-recursor container



Signed-off-by: kberger65 <kberger@suse.com>