### PR TITLE
Add the nodeSelector to pdns and ironic containers

### DIFF
--- a/helm-charts/ironic/templates/deployment.yaml
+++ b/helm-charts/ironic/templates/deployment.yaml
@@ -157,6 +157,10 @@ spec:
           defaultMode: 493
           name: ironic-certs       
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.global.dnsPolicy }}
       dnsPolicy:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/ironic/values.yaml
+++ b/helm-charts/ironic/values.yaml
@@ -128,6 +128,15 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# In a multi-node kubernetes cluster, we need to "pin" the
+# ironic containers to the given host where the
+# provisioningIP exists. Uncomment the nodeSelector
+# here and update the hostanme accordingly.
+#nodeSelector: 
+  #kubernetes.io/hostname: "csrancher-n1"
+
+# Comment this out when running in a multi-node kubernetes cluster
+# and using the nodeSelector above.
 nodeSelector: {}
 
 tolerations: []

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -100,6 +100,12 @@ metal3-powerdns:
     # *Must match the global.dnsDomain setting specified above*
     name: suse.baremetal
 
+  # If using the pdnsIP and running in a multi-node kubernetes
+  # cluster, we need to "pin" the pdns containers to the given
+  # host where the pdnsIP exists. Uncomment the nodeSelector
+  # here and update the hostanme accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "my-node"
 
 #
 # external-dns service
@@ -175,3 +181,10 @@ metal3-ironic:
     # The base URL to download IPA images (i.e. ironic-python-agent.tar 
     # and ironic-python-agent.tar.md5).
     ipaBaseUri: "http://10.84.144.252/metal3"
+
+  # In a multi-node kubernetes cluster, we need to "pin" the
+  # ironic containers to the given host where the
+  # provisioningIP exists. Uncomment the nodeSelector
+  # here and update the hostanme accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "my-node"

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -79,6 +79,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# If using the pdnsIP and running in a multi-node kubernetes
+# cluster, we need to "pin" the pdns containers to the given
+# host where the pdnsIP exists. Uncomment the nodeSelector
+# here and update the hostanme accordingly.
+#nodeSelector: 
+  #kubernetes.io/hostname: "csrancher-n2"
+
+# Comment this out when using pdnsIP AND running in a multi-node
+# kubernetes cluster and using the nodeSelector above.
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This PR adds steps for pinning the powerdns and ironic containers to a specific host.  In a multi-node cluster,  the ironic container needs runs on the host where the provisioningIP exists.  Similarly, if you hostNetwork for the power dns container, it must run on the host where the pdnsIP exists. 

Signed-off-by: KeithMnemonic <keith.berger@suse.com>