### PR TITLE
Additional updates to support a multinode cluster

### DIFF
--- a/helm-charts/baremetal-operator/values.yaml
+++ b/helm-charts/baremetal-operator/values.yaml
@@ -18,6 +18,23 @@ global:
   # IP Address assigned to network interface on provisioning network
   provisioningIP: 192.168.20.5
 
+  # If using pdnsIP for to set powerdns to use hostNetwork, update
+  # the nameservers to the pdnsIP address
+  dnsConfig:
+    nameservers:
+    - 10.43.255.254
+    searches:
+    - suse.baremetal
+
+  # If running in a multi-node kubernetes cluster, "pin" the baremtal container
+  # to the same host where the ironic, external-dns, pdns, and media containers
+  # arerunning. Uncomment the nodeSelector and update the hostname accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "my-hostname"
+
+  # Comment this out when pinning the baremetal-operator container to a specfic host.
+  nodeSelector: {}
+
 replicaCount: 1
 
 image:
@@ -90,8 +107,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-nodeSelector: {}
 
 tolerations: []
 

--- a/helm-charts/ironic/templates/deployment.yaml
+++ b/helm-charts/ironic/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
           defaultMode: 493
           name: ironic-certs       
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/ironic/values.yaml
+++ b/helm-charts/ironic/values.yaml
@@ -11,6 +11,10 @@ global:
   # IP address of the router associated with the specified DHCP
   # address range
   dnsmasqDefaultRouter: 192.168.21.254
+  
+  # IP address of the dns server to be provided with DHCP
+  # response
+  dnsmasqDNSServer: 192.168.20.5
 
   # specify comma serparate beginning and end of the range of IP
   # addresses the DHCP server will manage.
@@ -28,6 +32,24 @@ global:
     annotations: {}
       # The IP to register with external-dns for this service
       #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  # If using pdnsIP for to set powerdns to use hostNetwork, update
+  # the nameservers to the pdnsIP address
+  dnsConfig:
+    nameservers:
+    - 10.43.255.254
+    searches:
+    - suse.baremetal
+
+  # In a multi-node kubernetes cluster, we need to "pin" the
+  # ironic containers to the given host where the
+  # provisioningIP exists. Uncomment the nodeSelector
+  # here and update the hostname accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "csrancher-n1"
+
+  # Comment this out when pinning the pdns containers to a specfic host.
+  nodeSelector: {}
 
 replicaCount: 1
 
@@ -127,17 +149,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-# In a multi-node kubernetes cluster, we need to "pin" the
-# ironic containers to the given host where the
-# provisioningIP exists. Uncomment the nodeSelector
-# here and update the hostanme accordingly.
-#nodeSelector: 
-  #kubernetes.io/hostname: "csrancher-n1"
-
-# Comment this out when running in a multi-node kubernetes cluster
-# and using the nodeSelector above.
-nodeSelector: {}
 
 tolerations: []
 
@@ -249,7 +260,7 @@ baremetaloperator:
   dhcpHosts: ""
 
   bootServerAddress: "boot.ironic.{{ .Values.global.dnsDomain }}"
-  dnsmasqDnsServerAddress: "{{ .Values.global.provisioningIP }}"
+  dnsmasqDnsServerAddress: "{{ .Values.global.dnsmasqDNSServer }}"
   httpPort: "6180"
 
   ipaBaseUri: "http://10.84.144.252/metal3"

--- a/helm-charts/media/templates/deployment.yaml
+++ b/helm-charts/media/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/media/values.yaml
+++ b/helm-charts/media/values.yaml
@@ -10,6 +10,23 @@ global:
       # The IP to register with external-dns for this service
       #external-dns.alpha.kubernetes.io/target: 192.168.20.5
 
+  # If using pdnsIP for to set powerdns to use hostNetwork, update
+  # the nameservers to the pdnsIP address
+  dnsConfig:
+    nameservers:
+    - 10.43.255.254
+    searches:
+    - suse.baremetal
+
+  # If running in a multi-node kubernetes cluster, "pin" the media container
+  # to the given host where the /opt/media volume exists. Uncomment the
+  # nodeSelector and update the hostname accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "my-hostname"
+
+  # Comment this out when pinning the media container to a specfic host.
+  nodeSelector: {}
+
 replicaCount: 1
 
 image:
@@ -82,8 +99,6 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-nodeSelector: {}
 
 tolerations: []
 

--- a/helm-charts/metal3-deploy/values.yaml
+++ b/helm-charts/metal3-deploy/values.yaml
@@ -17,6 +17,11 @@ global:
 
   dnsPolicy: "None"
 
+  # set pdnsIP to enable hostNetwork in the pdns-recursor container
+  # and bind pdns-recursor to port 53 using the pdnsIP address
+  #pdnsIP: 192.168.20.5
+
+  # If using pdnsIP, update the nameservers to the pdnsIP address
   dnsConfig:
     nameservers:
     - 10.43.255.254
@@ -26,6 +31,10 @@ global:
   # IP address of the router associated with the specified DHCP
   # address range
   dnsmasqDefaultRouter: 192.168.21.254
+
+  # IP address of the dns server to be provided with DHCP
+  # response
+  dnsmasqDNSServer: 192.168.20.5
 
   # specify comma serparate beginning and end of the range of IP
   # addresses the DHCP server will manage.
@@ -37,17 +46,19 @@ global:
   # IP Address assigned to network interface on provisioning network
   provisioningIP: 192.168.20.5
 
-  # set pdnsIP to enable hostNetwork in the pdns-recursor container
-  # and bind pdns-recursor to port 53 using the pdnsIP address
-
-  #pdnsIP: 192.168.20.5
-
   # Global ingress annotations that is shared by all the ingress services.
   # For example, use it to override extern-dns records.
   ingress:
     annotations: {}
       # The IP to register with external-dns for this service
       #external-dns.alpha.kubernetes.io/target: 192.168.20.5
+
+  # In a multi-node cluster use the node selector to ensure the pods
+  # all run on the same host where the dnsmasqDNSServer and provisioningIP
+  # and /opt/media exist. Uncomment the nodeSelector and update the
+  # hostname accordingly.
+  #nodeSelector:
+    #kubernetes.io/hostname: "csrancher-n1"
 
 
 #
@@ -99,13 +110,6 @@ metal3-powerdns:
     # DNS domain that PowerDNS will manage
     # *Must match the global.dnsDomain setting specified above*
     name: suse.baremetal
-
-  # If using the pdnsIP and running in a multi-node kubernetes
-  # cluster, we need to "pin" the pdns containers to the given
-  # host where the pdnsIP exists. Uncomment the nodeSelector
-  # here and update the hostanme accordingly.
-  #nodeSelector: 
-    #kubernetes.io/hostname: "my-node"
 
 #
 # external-dns service
@@ -181,10 +185,3 @@ metal3-ironic:
     # The base URL to download IPA images (i.e. ironic-python-agent.tar 
     # and ironic-python-agent.tar.md5).
     ipaBaseUri: "http://10.84.144.252/metal3"
-
-  # In a multi-node kubernetes cluster, we need to "pin" the
-  # ironic containers to the given host where the
-  # provisioningIP exists. Uncomment the nodeSelector
-  # here and update the hostanme accordingly.
-  #nodeSelector: 
-    #kubernetes.io/hostname: "my-node"

--- a/helm-charts/powerdns/templates/deployment.yaml
+++ b/helm-charts/powerdns/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -15,6 +15,15 @@ global:
 
   #pdnsIP: 192.168.20.5
 
+  # If running in a multi-node kubernetes cluster, "pin" the pdns containers
+  # to the given host where the pdnsIP exists. Uncomment the nodeSelector
+  # and update the hostname accordingly.
+  #nodeSelector: 
+    #kubernetes.io/hostname: "my-hostname2"
+
+  # Comment this out when pinning the pdns containers to a specfic host.
+  nodeSelector: {}
+
 image:
   repository: registry.opensuse.org/isv/metal3/bci/containerfile/suse/pdns
   pullPolicy: IfNotPresent
@@ -78,17 +87,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
-# If using the pdnsIP and running in a multi-node kubernetes
-# cluster, we need to "pin" the pdns containers to the given
-# host where the pdnsIP exists. Uncomment the nodeSelector
-# here and update the hostanme accordingly.
-#nodeSelector: 
-  #kubernetes.io/hostname: "csrancher-n2"
-
-# Comment this out when using pdnsIP AND running in a multi-node
-# kubernetes cluster and using the nodeSelector above.
-nodeSelector: {}
 
 tolerations: []
 


### PR DESCRIPTION
This PR fixes a few remaining issues when deploying in a multi-node cluster. The nodeSelector and dnsConfig are moved to the global section. In addition, a new variable is added, dnsmasqDNSServer for those cases where the node where ironic runs is not the same as where external-dns or if a customer supplied DNS server is used