### PR TITLE
powerdns version change

### DIFF
--- a/helm-charts/powerdns/Chart.yaml
+++ b/helm-charts/powerdns/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.7.3"
+appVersion: "4.6.1"

--- a/helm-charts/powerdns/values.yaml
+++ b/helm-charts/powerdns/values.yaml
@@ -27,12 +27,12 @@ global:
 image:
   repository: registry.opensuse.org/isv/metal3/bci/containerfile/suse/pdns
   pullPolicy: IfNotPresent
-  tag: "4.7.3"
+  tag: "4.6.1"
 
 recursor_image:
   repository: registry.opensuse.org/isv/metal3/bci/containerfile/suse/pdns-recursor
   pullPolicy: IfNotPresent
-  tag: "4.8.0"
+  tag: "4.6.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Downgrading the version since the image
building process was updated to
use the official repos for updates
(providing better maintainability for these
dependent packages)
Also updated the chart version to match the
pdns version.